### PR TITLE
allow user specification of posterior covariance of hyperparams

### DIFF
--- a/demo/demo.m
+++ b/demo/demo.m
@@ -105,7 +105,7 @@ priors.mean = ...
     {get_prior(@gaussian_prior, 0, 0.5^2)};
 
 prior = get_prior(@independent_prior, priors);
-inference_method = add_prior_to_inference_method(inference_method, prior);
+inference_method = {@inference_with_prior, inference_method, prior};
 
 % find MAP hyperparameters
 map_hyperparameters = minimize(hyperparameters, @gp, 50, inference_method, ...

--- a/mgp.m
+++ b/mgp.m
@@ -179,12 +179,6 @@ function [y_star_mean, y_star_variance, ...
     posterior_cov = options.posterior_params;
   end
 
-  % % find GP posterior and Hessian of negative log likelihood evaluated
-  % % at the MLE/MAP \theta, as well as the derivatives of alpha and
-  % % diag W^{-1} with respect to \theta
-  % [posterior, ~, ~, HnlZ, dalpha, dWinv] = inference_method(hyperparameters, ...
-  %         mean_function, covariance_function, [], x, y);
-
   % find the predictive distribution conditioned on the MLE/MAP \theta
   if ((nargin > 8) && (nargout > 8) && ~isempty(y_star))
     % log probaiblities conditioned on MLE/MAP \theta requested


### PR DESCRIPTION
user can specify posterior covariance of hyperparams using a named argument: 

e.g.:
mgp(..., 'posterior_params', HnlZ)

this should work both when supplying y_star and not
